### PR TITLE
Improve splits parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "row-faster",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "dist/index.js",
   "directories": {
     "doc": "docs"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon --exec ts-node src/index.ts"
+    "dev": "nodemon --exec ts-node src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,15 +19,23 @@ app.post("/coach", async (req, res) => {
     return res.status(400).json({ error: "splits must be an array" });
   }
 
+  // Convert potential numeric strings and validate
+  const parsed = splits.map((s: unknown) => Number(s));
+  if (parsed.some((n) => Number.isNaN(n))) {
+    return res
+      .status(400)
+      .json({ error: "splits must contain only numeric values" });
+  }
+
   try {
     const reply = await openai.chat.completions.create({
       model: "gpt-4o-mini",
       messages: [
         {
           role: "user",
-          content: `My last rowing workout splits were ${splits.join(
-            ", "
-          )} sec/500m. Give me 3 coaching tips to improve.`,
+          content: `My last rowing workout splits were ${parsed
+            .map((n) => n.toFixed(2))
+            .join(", ")} sec/500m. Give me 3 coaching tips to improve.`,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- accept numeric strings in `splits` payload
- format splits using parsed numbers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688976a0582883228227a24e077abf32